### PR TITLE
feat: add SetLocation method to change torrent location dynamically

### DIFF
--- a/apiv2_test.go
+++ b/apiv2_test.go
@@ -218,6 +218,18 @@ func TestRenameFile(t *testing.T) {
 	}
 }
 
+func TestSetLocation(t *testing.T) {
+	cli, err := NewCli("http://localhost:8991")
+	if err != nil {
+		panic(err)
+	}
+	err = cli.SetLocation("/upload/anime",
+		"385191f125783e4dc16689f0ed7b5cf00961155d")
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestAddCategory(t *testing.T) {
 	cli, err := NewCli("http://localhost:8991")
 	if err != nil {

--- a/torrents.go
+++ b/torrents.go
@@ -292,6 +292,21 @@ func (c *Client) RenameFile(hash, old, new string) error {
 	return nil
 }
 
+func (c *Client) SetLocation(location string, hashes ...string) error {
+	hs := strings.Join(hashes, "|")
+	opt := Optional{
+		"hashes":   hs,
+		"location": location,
+	}
+	resp, err := c.postXwwwFormUrlencoded("torrents/setLocation", opt)
+	err = RespOk(resp, err)
+	if err != nil {
+		return err
+	}
+	ignrBody(resp.Body)
+	return nil
+}
+
 func (c *Client) RenameFolder(hash, old, new string) error {
 	opt := Optional{
 		"hash":    hash,


### PR DESCRIPTION
This PR adds the SetLocation method to the qBittorrent web API wrapper

This method allows users to change the location of torrents dynamically by specifying the new location and the hashes of the torrents to be moved

This method is based on this endpoint - https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#set-torrent-location